### PR TITLE
Fix ReferenceError: latlon is not defined error

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ exports.toBrng = function(deg, format, dp) {
 //radius of earth
 var radius = 6371;
 
-exports.latlon = function(lat, lon) {
+var latlon = exports.latlon = function(lat, lon) {
   // only accept numbers or valid numeric strings
   this.lat = typeof(lat)=='number' ? lat : typeof(lat)=='string' && lat.trim()!='' ? +lat : NaN;
   this.lng = typeof(lon)=='number' ? lon : typeof(lon)=='string' && lon.trim()!='' ? +lon : NaN;


### PR DESCRIPTION
Instantiating latlon like this fails:

```
new latlon();
```

Name spacing fixes it. Alternatively, we could re-write all

```
new latlon();
```

as 

```
new exports.latlon();
```
