### PR TITLE
Fix for Variables "leaking" to the global scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 //Original version of this module came from following website by Chris Veness
 //http://www.movable-type.co.uk/scripts/latlong.html

--- a/index.js
+++ b/index.js
@@ -292,8 +292,8 @@ exports.latlon.prototype.midpointTo = function(point) {
 
     var lon1 = this.lng.toRad();
 
-    lat3 = Math.atan2(Math.sin(lat1)+Math.sin(lat2), Math.sqrt( (Math.cos(lat1)+Bx)*(Math.cos(lat1)+Bx) + By*By) );
-    lon3 = lon1 + Math.atan2(By, Math.cos(lat1) + Bx);
+    var lat3 = Math.atan2(Math.sin(lat1)+Math.sin(lat2), Math.sqrt( (Math.cos(lat1)+Bx)*(Math.cos(lat1)+Bx) + By*By) );
+    var lon3 = lon1 + Math.atan2(By, Math.cos(lat1) + Bx);
     lon3 = (lon3+3*Math.PI) % (2*Math.PI) - Math.PI;  // normalise to -180..+180º
 
     return new exports.latlon(lat3.toDeg(), lon3.toDeg());
@@ -419,32 +419,32 @@ exports.latlon.prototype.destinationPoint = function(brng, dist) {
 exports.latlon.intersection = function(p1, brng1, p2, brng2) {
   brng1 = typeof brng1 == 'number' ? brng1 : typeof brng1 == 'string' && trim(brng1)!='' ? +brng1 : NaN;
   brng2 = typeof brng2 == 'number' ? brng2 : typeof brng2 == 'string' && trim(brng2)!='' ? +brng2 : NaN;
-  lat1 = p1.lat.toRad(), lon1 = p1.lng.toRad();
-  lat2 = p2.lat.toRad(), lon2 = p2.lng.toRad();
-  brng13 = brng1.toRad(), brng23 = brng2.toRad();
-  dLat = lat2-lat1, dLon = lon2-lon1;
+  var lat1 = p1.lat.toRad(), lon1 = p1.lng.toRad();
+  var lat2 = p2.lat.toRad(), lon2 = p2.lng.toRad();
+  var brng13 = brng1.toRad(), brng23 = brng2.toRad();
+  var dLat = lat2-lat1, dLon = lon2-lon1;
 
-  dist12 = 2*Math.asin( Math.sqrt( Math.sin(dLat/2)*Math.sin(dLat/2) +
+  var dist12 = 2*Math.asin( Math.sqrt( Math.sin(dLat/2)*Math.sin(dLat/2) +
     Math.cos(lat1)*Math.cos(lat2)*Math.sin(dLon/2)*Math.sin(dLon/2) ) );
   if (dist12 == 0) return null;
 
   // initial/final bearings between points
-  brngA = Math.acos( ( Math.sin(lat2) - Math.sin(lat1)*Math.cos(dist12) ) /
+  var brngA = Math.acos( ( Math.sin(lat2) - Math.sin(lat1)*Math.cos(dist12) ) /
     ( Math.sin(dist12)*Math.cos(lat1) ) );
   if (isNaN(brngA)) brngA = 0;  // protect against rounding
-  brngB = Math.acos( ( Math.sin(lat1) - Math.sin(lat2)*Math.cos(dist12) ) /
+  var brngB = Math.acos( ( Math.sin(lat1) - Math.sin(lat2)*Math.cos(dist12) ) /
     ( Math.sin(dist12)*Math.cos(lat2) ) );
 
   if (Math.sin(lon2-lon1) > 0) {
-    brng12 = brngA;
-    brng21 = 2*Math.PI - brngB;
+    var brng12 = brngA;
+    var brng21 = 2*Math.PI - brngB;
   } else {
     brng12 = 2*Math.PI - brngA;
     brng21 = brngB;
   }
 
-  alpha1 = (brng13 - brng12 + Math.PI) % (2*Math.PI) - Math.PI;  // angle 2-1-3
-  alpha2 = (brng21 - brng23 + Math.PI) % (2*Math.PI) - Math.PI;  // angle 1-2-3
+  var alpha1 = (brng13 - brng12 + Math.PI) % (2*Math.PI) - Math.PI;  // angle 2-1-3
+  var alpha2 = (brng21 - brng23 + Math.PI) % (2*Math.PI) - Math.PI;  // angle 1-2-3
 
   if (Math.sin(alpha1)==0 && Math.sin(alpha2)==0) return null;  // infinite intersections
   if (Math.sin(alpha1)*Math.sin(alpha2) < 0) return null;       // ambiguous intersection
@@ -453,15 +453,15 @@ exports.latlon.intersection = function(p1, brng1, p2, brng2) {
   //alpha2 = Math.abs(alpha2);
   // ... Ed Williams takes abs of alpha1/alpha2, but seems to break calculation?
 
-  alpha3 = Math.acos( -Math.cos(alpha1)*Math.cos(alpha2) +
+  var alpha3 = Math.acos( -Math.cos(alpha1)*Math.cos(alpha2) +
                        Math.sin(alpha1)*Math.sin(alpha2)*Math.cos(dist12) );
-  dist13 = Math.atan2( Math.sin(dist12)*Math.sin(alpha1)*Math.sin(alpha2),
+  var dist13 = Math.atan2( Math.sin(dist12)*Math.sin(alpha1)*Math.sin(alpha2),
                        Math.cos(alpha2)+Math.cos(alpha1)*Math.cos(alpha3) )
-  lat3 = Math.asin( Math.sin(lat1)*Math.cos(dist13) +
+  var lat3 = Math.asin( Math.sin(lat1)*Math.cos(dist13) +
                     Math.cos(lat1)*Math.sin(dist13)*Math.cos(brng13) );
-  dLon13 = Math.atan2( Math.sin(brng13)*Math.sin(dist13)*Math.cos(lat1),
+  var dLon13 = Math.atan2( Math.sin(brng13)*Math.sin(dist13)*Math.cos(lat1),
                        Math.cos(dist13)-Math.sin(lat1)*Math.sin(lat3) );
-  lon3 = lon1+dLon13;
+  var lon3 = lon1+dLon13;
   lon3 = (lon3+3*Math.PI) % (2*Math.PI) - Math.PI;  // normalise to -180..+180º
 
   return new exports.latlon(lat3.toDeg(), lon3.toDeg());
@@ -540,7 +540,7 @@ exports.latlon.prototype.rhumbDestinationPoint = function(brng, dist) {
   // check for some daft bugger going past the pole, normalise latitude if so
   if (Math.abs(lat2) > Math.PI/2) lat2 = lat2>0 ? Math.PI-lat2 : -Math.PI-lat2;
 
-  lon2 = (lon1+dLon+3*Math.PI)%(2*Math.PI) - Math.PI;
+  var lon2 = (lon1+dLon+3*Math.PI)%(2*Math.PI) - Math.PI;
 
   return new exports.latlon(lat2.toDeg(), lon2.toDeg());
 }
@@ -553,8 +553,8 @@ exports.latlon.prototype.rhumbDestinationPoint = function(brng, dist) {
  * @returns {latlon} Midpoint between this point and the supplied point
  */
 exports.latlon.prototype.rhumbMidpointTo = function(point) {
-  lat1 = this.lat.toRad(), lon1 = this.lng.toRad();
-  lat2 = point.lat.toRad(), lon2 = point.lng.toRad();
+  var lat1 = this.lat.toRad(), lon1 = this.lng.toRad();
+  var lat2 = point.lat.toRad(), lon2 = point.lng.toRad();
 
   if (Math.abs(lon2-lon1) > Math.PI) lon1 += 2*Math.PI; // crossing anti-meridian
 
@@ -649,7 +649,7 @@ if (typeof Number.prototype.toPrecisionFixed == 'undefined') {
     // ... but replace +ve exponential format with trailing zeros
     n = n.replace(/(.+)e\+(.+)/, function(n, sig, exp) {
       sig = sig.replace(/\./, '');       // remove decimal from significand
-      l = sig.length - 1;
+      var l = sig.length - 1;
       while (exp-- > l) sig = sig + '0'; // append zeros from exponent
       return sig;
     });


### PR DESCRIPTION
As the commit message says, this PR fixes local variables not being declared with a "var" at the start of the line.

Currently, this library leaks lots of globals, which can trigger test failures, for example when using `--check-leaks` in Mocha.